### PR TITLE
PR3: Test-taking flow — screens 2a/2b/2c, test-run API, soft timer, test mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,40 @@ docs/       ANALYSIS.md · PLAN.md · adr/ (architecture decisions) · research/
 CONTEXT.md  domain glossary
 ```
 
+## Testing
+
+Backend API and scoring tests run with pytest. The API tests need a Postgres —
+they use a dedicated `bigfive_test` database (never the app's data) reachable on
+the host. With the Compose stack up:
+
+```bash
+docker compose exec -T db psql -U bigfive -d bigfive -c "CREATE DATABASE bigfive_test"  # one-time
+cd backend && DB_PORT=<host-db-port> .venv/bin/pytest   # DB_PORT matches your .env (default 5432)
+```
+
+Tests that need the database are skipped automatically if it is unreachable, so
+the scoring/parity/health tests still run without one.
+
+Frontend type-check + production build:
+
+```bash
+docker compose exec -T frontend npm run build
+```
+
+### Test mode (dev only)
+
+Set `VITE_TEST_MODE=true` in `.env` to expose hidden controls that drive a full
+run fast without hand-answering 120 items:
+
+- **Start screen** — demographics are prefilled (age 30, male) so a run begins in
+  one click.
+- **Test screen** — a dashed **"⚡ Autofill & finish"** button answers every
+  remaining item with a random 1–5 through the normal answer path, then completes
+  the run and jumps to the report.
+
+With the flag unset (the default) these controls are absent from the DOM. Never
+enable test mode in production.
+
 ## Documentation
 
 - **[docs/PLAN.md](docs/PLAN.md)** — development plan and PR sequence

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -8,6 +8,7 @@ from sqlalchemy.pool import NullPool
 
 from app.core.config import get_settings
 from app.core.db import Base
+from app import models  # noqa: F401  (registers tables on Base.metadata)
 
 # Alembic Config object, provides access to the .ini values.
 config = context.config

--- a/backend/alembic/versions/a1b2c3d4e5f6_test_flow_schema.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_test_flow_schema.py
@@ -1,0 +1,108 @@
+"""test flow schema: profiles, test_runs, answers
+
+Revision ID: a1b2c3d4e5f6
+Revises: e72a84c0121a
+Create Date: 2026-07-11 21:00:00.000000
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | None = "e72a84c0121a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "profiles",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "test_runs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("profile_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "form",
+            postgresql.ENUM("full", "quick", name="form"),
+            nullable=False,
+        ),
+        sa.Column("age", sa.Integer(), nullable=False),
+        sa.Column(
+            "sex",
+            postgresql.ENUM("male", "female", name="sex"),
+            nullable=False,
+        ),
+        sa.Column(
+            "status",
+            postgresql.ENUM(
+                "in_progress", "completed", "abandoned", name="run_status"
+            ),
+            nullable=False,
+        ),
+        sa.Column("scores", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "age >= 13 AND age <= 120", name="ck_test_runs_age_range"
+        ),
+        sa.ForeignKeyConstraint(
+            ["profile_id"], ["profiles.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_test_runs_profile_id", "test_runs", ["profile_id"], unique=False
+    )
+
+    op.create_table(
+        "answers",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("run_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("item_id", sa.Integer(), nullable=False),
+        sa.Column("value", sa.Integer(), nullable=False),
+        sa.Column(
+            "answered_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "value >= 1 AND value <= 5", name="ck_answers_value_range"
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_id"], ["test_runs.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("run_id", "item_id", name="uq_answers_run_item"),
+    )
+    op.create_index("ix_answers_run_id", "answers", ["run_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_answers_run_id", table_name="answers")
+    op.drop_table("answers")
+    op.drop_index("ix_test_runs_profile_id", table_name="test_runs")
+    op.drop_table("test_runs")
+    op.drop_table("profiles")
+    op.execute("DROP TYPE IF EXISTS run_status")
+    op.execute("DROP TYPE IF EXISTS sex")
+    op.execute("DROP TYPE IF EXISTS form")

--- a/backend/app/api/v1/schemas.py
+++ b/backend/app/api/v1/schemas.py
@@ -1,0 +1,73 @@
+"""Request/response models for the test-run API (all /api/v1)."""
+
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel, Field
+
+from app.models import Form, RunStatus, Sex
+
+
+class ProfileCreated(BaseModel):
+    id: uuid.UUID
+
+
+class TestRunCreate(BaseModel):
+    profile_id: uuid.UUID
+    form: Form
+    age: int = Field(ge=13, le=120)
+    sex: Sex
+
+
+class TestRunCreated(BaseModel):
+    id: uuid.UUID
+    item_count: int
+
+
+class AnswerCreate(BaseModel):
+    item_id: int
+    value: int = Field(ge=1, le=5)
+
+
+class FacetScoreOut(BaseModel):
+    domain: str
+    number: int
+    name: str
+    raw: int
+    t_score: float
+    percentile: int
+    level: str
+
+
+class DomainScoreOut(BaseModel):
+    domain: str
+    name: str
+    raw: int
+    t_score: float
+    percentile: int
+    level: str
+    facets: list[FacetScoreOut]
+
+
+class ScoreResultOut(BaseModel):
+    """The full scored result of a completed run.
+
+    ``domains`` and ``facets`` are flattened lists (facets carry a ``domain``
+    letter) so the client can render either grouping without re-deriving order.
+    """
+
+    run_id: uuid.UUID
+    age: int
+    sex: str
+    domains: list[DomainScoreOut]
+    facets: list[FacetScoreOut]
+
+
+class TestRunStatus(BaseModel):
+    id: uuid.UUID
+    status: RunStatus
+    form: Form
+    item_count: int
+    answered_count: int
+    scores: ScoreResultOut | None = None

--- a/backend/app/api/v1/test_runs.py
+++ b/backend/app/api/v1/test_runs.py
@@ -1,0 +1,185 @@
+"""Test-run lifecycle API (all under /api/v1).
+
+Endpoints:
+  POST /profiles                     -> issue an anonymous Profile
+  POST /test-runs                    -> start a run for a Profile + Form
+  POST /test-runs/{id}/answers       -> commit one one-shot Answer
+  POST /test-runs/{id}/complete      -> score a fully-answered run
+  POST /test-runs/{id}/abandon       -> abandon a run (idempotent)
+  GET  /test-runs/{id}               -> status (+ scores if completed)
+
+Answers are one-shot (ADR-0001): a duplicate ``(run_id, item_id)`` is a 409, not
+an overwrite. Completion requires every Item of the Form to be answered.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.schemas import (
+    AnswerCreate,
+    ProfileCreated,
+    ScoreResultOut,
+    TestRunCreate,
+    TestRunCreated,
+    TestRunStatus,
+)
+from app.core.db import get_session
+from app.models import Answer, Form, Profile, RunStatus, TestRun
+from app.scoring import forms
+from app.scoring.engine import score
+from app.scoring.serialize import score_result_to_dict
+
+router = APIRouter()
+
+
+async def _get_run(session: AsyncSession, run_id: uuid.UUID) -> TestRun:
+    run = await session.get(TestRun, run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="test run not found")
+    return run
+
+
+@router.post("/profiles", status_code=201)
+async def create_profile(
+    session: AsyncSession = Depends(get_session),
+) -> ProfileCreated:
+    """Issue a fresh anonymous Profile (no body needed)."""
+    profile = Profile()
+    session.add(profile)
+    await session.commit()
+    return ProfileCreated(id=profile.id)
+
+
+@router.post("/test-runs", status_code=201)
+async def create_test_run(
+    payload: TestRunCreate,
+    session: AsyncSession = Depends(get_session),
+) -> TestRunCreated:
+    """Start a Test Run. Quick is not implemented yet (ADR-0004) -> 501."""
+    if payload.form == Form.quick:
+        raise HTTPException(status_code=501, detail="Quick form coming soon")
+
+    profile = await session.get(Profile, payload.profile_id)
+    if profile is None:
+        raise HTTPException(status_code=404, detail="profile not found")
+
+    run = TestRun(
+        profile_id=payload.profile_id,
+        form=payload.form,
+        age=payload.age,
+        sex=payload.sex,
+        status=RunStatus.in_progress,
+    )
+    session.add(run)
+    await session.commit()
+    return TestRunCreated(id=run.id, item_count=forms.item_count(payload.form.value))
+
+
+@router.post("/test-runs/{run_id}/answers", status_code=204)
+async def create_answer(
+    run_id: uuid.UUID,
+    payload: AnswerCreate,
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    """Commit one Answer. One-shot: duplicate item -> 409 (ADR-0001)."""
+    run = await _get_run(session, run_id)
+    if run.status != RunStatus.in_progress:
+        raise HTTPException(status_code=409, detail="test run is not in progress")
+
+    valid_ids = forms.item_ids(run.form.value)
+    if payload.item_id not in valid_ids:
+        raise HTTPException(
+            status_code=422, detail=f"unknown item for form: {payload.item_id}"
+        )
+
+    existing = await session.scalar(
+        select(Answer).where(
+            Answer.run_id == run_id, Answer.item_id == payload.item_id
+        )
+    )
+    if existing is not None:
+        raise HTTPException(status_code=409, detail="item already answered")
+
+    session.add(
+        Answer(run_id=run_id, item_id=payload.item_id, value=payload.value)
+    )
+    await session.commit()
+    return Response(status_code=204)
+
+
+@router.post("/test-runs/{run_id}/complete")
+async def complete_test_run(
+    run_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+) -> ScoreResultOut:
+    """Score a fully-answered run; persist scores and mark completed."""
+    run = await _get_run(session, run_id)
+
+    if run.status == RunStatus.completed and run.scores is not None:
+        # Idempotent-ish: re-completing a completed run returns its stored scores.
+        return ScoreResultOut(**run.scores)
+    if run.status != RunStatus.in_progress:
+        raise HTTPException(status_code=409, detail="test run is not in progress")
+
+    rows = await session.execute(
+        select(Answer.item_id, Answer.value).where(Answer.run_id == run_id)
+    )
+    answers = {item_id: value for item_id, value in rows.all()}
+
+    expected = forms.item_ids(run.form.value)
+    if set(answers) != set(expected):
+        missing = len(expected) - len(set(answers) & set(expected))
+        raise HTTPException(
+            status_code=422,
+            detail=f"run is incomplete: {missing} of {len(expected)} items unanswered",
+        )
+
+    result = score(answers, run.age, run.sex.value)
+    scores_dict = score_result_to_dict(result, str(run_id))
+
+    run.scores = scores_dict
+    run.status = RunStatus.completed
+    run.completed_at = datetime.now(timezone.utc)
+    await session.commit()
+
+    return ScoreResultOut(**scores_dict)
+
+
+@router.post("/test-runs/{run_id}/abandon", status_code=200)
+async def abandon_test_run(
+    run_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Abandon a run. Idempotent; completed runs are left untouched."""
+    run = await _get_run(session, run_id)
+    if run.status == RunStatus.in_progress:
+        run.status = RunStatus.abandoned
+        await session.commit()
+    return {"id": str(run.id), "status": run.status.value}
+
+
+@router.get("/test-runs/{run_id}")
+async def get_test_run(
+    run_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+) -> TestRunStatus:
+    """Return run status plus scores if the run is completed."""
+    run = await _get_run(session, run_id)
+    answered_count = await session.scalar(
+        select(func.count()).select_from(Answer).where(Answer.run_id == run_id)
+    )
+    scores = ScoreResultOut(**run.scores) if run.scores is not None else None
+    return TestRunStatus(
+        id=run.id,
+        status=run.status,
+        form=run.form,
+        item_count=forms.item_count(run.form.value),
+        answered_count=answered_count or 0,
+        scores=scores,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api.v1 import forms, health
+from app.api.v1 import forms, health, test_runs
 from app.core.config import get_settings
 
 
@@ -19,6 +19,7 @@ def create_app() -> FastAPI:
 
     app.include_router(health.router, prefix="/api/v1")
     app.include_router(forms.router, prefix="/api/v1")
+    app.include_router(test_runs.router, prefix="/api/v1")
     return app
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,130 @@
+"""SQLAlchemy ORM models for the test-taking flow.
+
+A :class:`Profile` is the anonymous identity everything hangs off (ADR-0002).
+It owns many :class:`TestRun` rows; each run collects one :class:`Answer` per
+Item of its Form. Answers are one-shot — no revisions, no gaps (ADR-0001) —
+enforced by a unique constraint on ``(run_id, item_id)``.
+
+Scores are persisted as JSONB on the run at completion (the full engine
+``ScoreResult`` shape), so a completed run is self-contained and the report can
+be re-rendered without re-scoring.
+"""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Integer,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.db import Base
+
+
+class Form(str, enum.Enum):
+    full = "full"
+    quick = "quick"
+
+
+class Sex(str, enum.Enum):
+    male = "male"
+    female = "female"
+
+
+class RunStatus(str, enum.Enum):
+    in_progress = "in_progress"
+    completed = "completed"
+    abandoned = "abandoned"
+
+
+class Profile(Base):
+    __tablename__ = "profiles"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    test_runs: Mapped[list[TestRun]] = relationship(
+        back_populates="profile", cascade="all, delete-orphan"
+    )
+
+
+class TestRun(Base):
+    __tablename__ = "test_runs"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    profile_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("profiles.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    form: Mapped[Form] = mapped_column(
+        Enum(Form, name="form"), nullable=False
+    )
+    age: Mapped[int] = mapped_column(Integer, nullable=False)
+    sex: Mapped[Sex] = mapped_column(Enum(Sex, name="sex"), nullable=False)
+    status: Mapped[RunStatus] = mapped_column(
+        Enum(RunStatus, name="run_status"),
+        nullable=False,
+        default=RunStatus.in_progress,
+    )
+    # Full engine ScoreResult, persisted at completion; null until then.
+    scores: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    profile: Mapped[Profile] = relationship(back_populates="test_runs")
+    answers: Mapped[list[Answer]] = relationship(
+        back_populates="run", cascade="all, delete-orphan"
+    )
+
+    __table_args__ = (
+        CheckConstraint("age >= 13 AND age <= 120", name="ck_test_runs_age_range"),
+    )
+
+
+class Answer(Base):
+    __tablename__ = "answers"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    run_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("test_runs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    item_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    # Raw slider value 1..5; keying is applied by the engine at scoring time.
+    value: Mapped[int] = mapped_column(Integer, nullable=False)
+    answered_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    run: Mapped[TestRun] = relationship(back_populates="answers")
+
+    __table_args__ = (
+        UniqueConstraint("run_id", "item_id", name="uq_answers_run_item"),
+        CheckConstraint("value >= 1 AND value <= 5", name="ck_answers_value_range"),
+    )

--- a/backend/app/scoring/forms.py
+++ b/backend/app/scoring/forms.py
@@ -1,0 +1,34 @@
+"""Form metadata shared by the API layer.
+
+Keeps knowledge of which Items belong to which Form in the scoring package so
+the API never hard-codes item counts or IDs. Quick is not yet backed by a bank
+(ADR-0004) — its item set is empty until PR6.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from app.scoring.engine import _load_items
+
+FULL = "full"
+QUICK = "quick"
+KNOWN_FORMS = frozenset({FULL, QUICK})
+
+
+@lru_cache(maxsize=1)
+def full_item_ids() -> frozenset[int]:
+    """The set of valid Item IDs for the Full form (1..120)."""
+    return frozenset(it["id"] for it in _load_items())
+
+
+def item_ids(form: str) -> frozenset[int]:
+    """Valid Item IDs for ``form``. Quick is empty until its bank lands."""
+    if form == FULL:
+        return full_item_ids()
+    return frozenset()
+
+
+def item_count(form: str) -> int:
+    """Number of Items in ``form``."""
+    return len(item_ids(form))

--- a/backend/app/scoring/serialize.py
+++ b/backend/app/scoring/serialize.py
@@ -1,0 +1,48 @@
+"""Serialize an engine :class:`ScoreResult` to a plain JSON-able dict.
+
+This is the exact shape persisted to ``test_runs.scores`` (JSONB) and returned
+by the complete / get-run endpoints. Keeping it here means the storage shape and
+the wire shape are defined in one place, next to the engine it mirrors.
+"""
+
+from __future__ import annotations
+
+from app.scoring.engine import ScoreResult
+
+
+def score_result_to_dict(result: ScoreResult, run_id: str) -> dict:
+    """Flatten a ScoreResult into nested domains plus a flat facet list."""
+    domains = []
+    facets = []
+    for domain in result.domains.values():
+        domain_facets = []
+        for f in domain.facets:
+            facet_dict = {
+                "domain": domain.domain,
+                "number": f.number,
+                "name": f.name,
+                "raw": f.raw,
+                "t_score": f.t_score,
+                "percentile": f.percentile,
+                "level": f.level,
+            }
+            domain_facets.append(facet_dict)
+            facets.append(facet_dict)
+        domains.append(
+            {
+                "domain": domain.domain,
+                "name": domain.name,
+                "raw": domain.raw,
+                "t_score": domain.t_score,
+                "percentile": domain.percentile,
+                "level": domain.level,
+                "facets": domain_facets,
+            }
+        )
+    return {
+        "run_id": run_id,
+        "age": result.age,
+        "sex": result.sex,
+        "domains": domains,
+        "facets": facets,
+    }

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,75 @@
+"""Shared test fixtures.
+
+API tests run against a real Postgres (the models use Postgres UUID/JSONB/enum
+types, which SQLite can't emulate faithfully). The database URL is taken from
+``TEST_DATABASE_URL`` if set, else the app's configured ``DATABASE_URL`` with
+the host swapped to localhost so tests can run from the host against the
+Compose Postgres. Tests that need the DB are skipped if it is unreachable.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.core.db import Base, get_session
+from app.main import app
+
+
+def _test_database_url() -> str:
+    explicit = os.environ.get("TEST_DATABASE_URL")
+    if explicit:
+        return explicit
+    # Reach the Compose Postgres from the host. The mapped host port defaults to
+    # 55432 (see the local .env); override with DB_PORT. Tests use a DEDICATED
+    # database (bigfive_test) so create_all/drop_all never touch the app's data.
+    port = os.environ.get("DB_PORT", "55432")
+    db = os.environ.get("TEST_DB_NAME", "bigfive_test")
+    return f"postgresql+asyncpg://bigfive:bigfive@localhost:{port}/{db}"
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    """Create all tables on a real Postgres, yield a session, then drop them.
+
+    Skips the test if Postgres is unreachable so the suite still runs (health
+    and forms tests do not need the DB) in environments without a database.
+    """
+    engine = create_async_engine(_test_database_url(), future=True)
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+            await conn.run_sync(Base.metadata.create_all)
+    except Exception as exc:  # pragma: no cover - env-dependent
+        await engine.dispose()
+        pytest.skip(f"Postgres unavailable for DB test: {exc}")
+
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def override_get_session():
+        async with factory() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    try:
+        async with factory() as session:
+            yield session
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(db_session):
+    """An httpx client bound to the ASGI app with the DB override applied."""
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c

--- a/backend/tests/test_runs_api.py
+++ b/backend/tests/test_runs_api.py
@@ -1,0 +1,151 @@
+"""API-level tests for the test-run lifecycle.
+
+These exercise the real endpoints against a real Postgres (see conftest).
+Happy path answers all 120 items via the API and asserts the completed scores
+match the pure engine's output for the same answers/demographics.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.scoring.engine import score
+from app.scoring.serialize import score_result_to_dict
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _new_run(client, age=30, sex="male", form="full"):
+    prof = await client.post("/api/v1/profiles")
+    assert prof.status_code == 201
+    profile_id = prof.json()["id"]
+
+    run = await client.post(
+        "/api/v1/test-runs",
+        json={"profile_id": profile_id, "form": form, "age": age, "sex": sex},
+    )
+    assert run.status_code == 201
+    return run.json()["id"]
+
+
+async def test_create_profile_and_run(client):
+    run_id = await _new_run(client)
+    assert run_id
+
+    got = await client.get(f"/api/v1/test-runs/{run_id}")
+    assert got.status_code == 200
+    body = got.json()
+    assert body["status"] == "in_progress"
+    assert body["item_count"] == 120
+    assert body["answered_count"] == 0
+    assert body["scores"] is None
+
+
+async def test_quick_form_not_implemented(client):
+    prof = await client.post("/api/v1/profiles")
+    profile_id = prof.json()["id"]
+    run = await client.post(
+        "/api/v1/test-runs",
+        json={"profile_id": profile_id, "form": "quick", "age": 30, "sex": "male"},
+    )
+    assert run.status_code == 501
+
+
+async def test_age_out_of_range_rejected(client):
+    prof = await client.post("/api/v1/profiles")
+    profile_id = prof.json()["id"]
+    run = await client.post(
+        "/api/v1/test-runs",
+        json={"profile_id": profile_id, "form": "full", "age": 5, "sex": "male"},
+    )
+    assert run.status_code == 422
+
+
+async def test_full_run_happy_path_matches_engine(client):
+    age, sex = 30, "male"
+    run_id = await _new_run(client, age=age, sex=sex)
+
+    # A deterministic answer pattern across the 1..5 scale.
+    answers = {i: ((i * 7) % 5) + 1 for i in range(1, 121)}
+    for item_id, value in answers.items():
+        resp = await client.post(
+            f"/api/v1/test-runs/{run_id}/answers",
+            json={"item_id": item_id, "value": value},
+        )
+        assert resp.status_code == 204, resp.text
+
+    resp = await client.post(f"/api/v1/test-runs/{run_id}/complete")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    expected = score_result_to_dict(score(answers, age, sex), run_id)
+    assert body["domains"] == expected["domains"]
+    assert body["facets"] == expected["facets"]
+    assert len(body["domains"]) == 5
+    assert len(body["facets"]) == 30
+
+    # GET now returns completed status with the stored scores.
+    got = await client.get(f"/api/v1/test-runs/{run_id}")
+    assert got.json()["status"] == "completed"
+    assert got.json()["scores"]["domains"] == expected["domains"]
+
+
+async def test_duplicate_answer_conflicts(client):
+    run_id = await _new_run(client)
+    first = await client.post(
+        f"/api/v1/test-runs/{run_id}/answers",
+        json={"item_id": 1, "value": 3},
+    )
+    assert first.status_code == 204
+    dup = await client.post(
+        f"/api/v1/test-runs/{run_id}/answers",
+        json={"item_id": 1, "value": 5},
+    )
+    assert dup.status_code == 409
+
+
+async def test_unknown_item_rejected(client):
+    run_id = await _new_run(client)
+    resp = await client.post(
+        f"/api/v1/test-runs/{run_id}/answers",
+        json={"item_id": 999, "value": 3},
+    )
+    assert resp.status_code == 422
+
+
+async def test_complete_incomplete_run_rejected(client):
+    run_id = await _new_run(client)
+    await client.post(
+        f"/api/v1/test-runs/{run_id}/answers",
+        json={"item_id": 1, "value": 3},
+    )
+    resp = await client.post(f"/api/v1/test-runs/{run_id}/complete")
+    assert resp.status_code == 422
+
+
+async def test_abandon_is_idempotent_and_blocks_answers(client):
+    run_id = await _new_run(client)
+    first = await client.post(f"/api/v1/test-runs/{run_id}/abandon")
+    assert first.status_code == 200
+    assert first.json()["status"] == "abandoned"
+
+    again = await client.post(f"/api/v1/test-runs/{run_id}/abandon")
+    assert again.status_code == 200
+    assert again.json()["status"] == "abandoned"
+
+    # Answers rejected once abandoned.
+    resp = await client.post(
+        f"/api/v1/test-runs/{run_id}/answers",
+        json={"item_id": 1, "value": 3},
+    )
+    assert resp.status_code == 409
+
+
+async def test_answer_on_missing_run_404(client):
+    import uuid
+
+    resp = await client.post(
+        f"/api/v1/test-runs/{uuid.uuid4()}/answers",
+        json={"item_id": 1, "value": 3},
+    )
+    assert resp.status_code == 404

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
     working_dir: /app
     environment:
       VITE_API_PROXY_TARGET: http://backend:8000
+      VITE_TEST_MODE: ${VITE_TEST_MODE:-false}
     ports:
       - "${FRONTEND_PORT:-5173}:5173"
     volumes:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,6 +25,19 @@ defaulting to `http://localhost:8000` for host-run dev; Compose sets it to
 
 - `src/main.tsx` — entry (Query client + Router providers)
 - `src/router.tsx` — route table
-- `src/components/AppShell.tsx` — top-nav shell with the "Big Five" wordmark
-- `src/routes/` — `StartPage`, `TestPage`, `ReportPage`, `CoachPage`
+- `src/components/AppShell.tsx` — top-nav shell (Report/Coach); Start and Test
+  render their own full-bleed chrome
+- `src/routes/` — `StartPage` (2a), `TestPage` (2b), `ScoringPage` (2c),
+  `ReportPage`, `CoachPage`
+- `src/components/Slider.tsx` — continuous 0–100 slider mapped to a 1–5 Answer
+- `src/lib/useCountdown.ts` — the 30s soft timer (rAF; TimeBar semantics)
+- `src/store/runStore.ts` — zustand store for the active Test Run
+- `src/api/` — typed API client + `ensureProfileId` (localStorage Profile)
 - `src/theme/tokens.css` — design tokens (colors, radii, sticker shadows, type)
+
+## Test mode
+
+With `VITE_TEST_MODE=true` the Start screen prefills demographics and the Test
+screen shows an "⚡ Autofill & finish" control — see the repo `README.md`
+Testing section. The flag is read in `src/config.ts`; unset, the controls are
+absent from the DOM.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,72 @@
+import type {
+  AnswerCreate,
+  FormItems,
+  ProfileCreated,
+  ScoreResult,
+  TestRunCreated,
+  TestRunStatus,
+} from './types'
+
+const BASE = '/api/v1'
+
+export class ApiError extends Error {
+  status: number
+  constructor(status: number, message: string) {
+    super(message)
+    this.status = status
+    this.name = 'ApiError'
+  }
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const resp = await fetch(`${BASE}${path}`, {
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  })
+  if (!resp.ok) {
+    let detail = resp.statusText
+    try {
+      const body = await resp.json()
+      if (body?.detail) detail = typeof body.detail === 'string' ? body.detail : JSON.stringify(body.detail)
+    } catch {
+      // non-JSON error body; keep statusText
+    }
+    throw new ApiError(resp.status, detail)
+  }
+  if (resp.status === 204) return undefined as T
+  return (await resp.json()) as T
+}
+
+export interface AnswerCreateArgs extends AnswerCreate {
+  runId: string
+}
+
+export const api = {
+  createProfile: () => request<ProfileCreated>('/profiles', { method: 'POST' }),
+
+  getFormItems: (form: string) =>
+    request<FormItems>(`/forms/${form}/items`),
+
+  createTestRun: (body: {
+    profile_id: string
+    form: string
+    age: number
+    sex: string
+  }) => request<TestRunCreated>('/test-runs', { method: 'POST', body: JSON.stringify(body) }),
+
+  submitAnswer: ({ runId, item_id, value }: AnswerCreateArgs) =>
+    request<void>(`/test-runs/${runId}/answers`, {
+      method: 'POST',
+      body: JSON.stringify({ item_id, value }),
+    }),
+
+  completeTestRun: (runId: string) =>
+    request<ScoreResult>(`/test-runs/${runId}/complete`, { method: 'POST' }),
+
+  abandonTestRun: (runId: string) =>
+    request<{ id: string; status: string }>(`/test-runs/${runId}/abandon`, {
+      method: 'POST',
+    }),
+
+  getTestRun: (runId: string) => request<TestRunStatus>(`/test-runs/${runId}`),
+}

--- a/frontend/src/api/profile.ts
+++ b/frontend/src/api/profile.ts
@@ -1,0 +1,12 @@
+import { api } from './client'
+
+const PROFILE_KEY = 'bigfive.profileId'
+
+/** Return the persisted anonymous Profile id, minting one on first visit. */
+export async function ensureProfileId(): Promise<string> {
+  const existing = localStorage.getItem(PROFILE_KEY)
+  if (existing) return existing
+  const { id } = await api.createProfile()
+  localStorage.setItem(PROFILE_KEY, id)
+  return id
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1,0 +1,66 @@
+export type Form = 'full' | 'quick'
+export type Sex = 'male' | 'female'
+export type RunStatus = 'in_progress' | 'completed' | 'abandoned'
+
+export interface Item {
+  id: number
+  text: string
+  domain: string
+}
+
+export interface FormItems {
+  form: Form
+  count: number
+  items: Item[]
+}
+
+export interface ProfileCreated {
+  id: string
+}
+
+export interface TestRunCreated {
+  id: string
+  item_count: number
+}
+
+export interface AnswerCreate {
+  item_id: number
+  value: number
+}
+
+export interface FacetScore {
+  domain?: string
+  number: number
+  name: string
+  raw: number
+  t_score: number
+  percentile: number
+  level: string
+}
+
+export interface DomainScore {
+  domain: string
+  name: string
+  raw: number
+  t_score: number
+  percentile: number
+  level: string
+  facets: FacetScore[]
+}
+
+export interface ScoreResult {
+  run_id: string
+  age: number
+  sex: string
+  domains: DomainScore[]
+  facets: FacetScore[]
+}
+
+export interface TestRunStatus {
+  id: string
+  status: RunStatus
+  form: Form
+  item_count: number
+  answered_count: number
+  scores: ScoreResult | null
+}

--- a/frontend/src/components/Slider.module.css
+++ b/frontend/src/components/Slider.module.css
@@ -1,0 +1,93 @@
+.wrap {
+  width: 100%;
+  max-width: 640px;
+  margin-top: 14px;
+}
+
+.ends {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: var(--color-secondary);
+}
+
+.track {
+  position: relative;
+  height: 44px;
+  margin-top: 8px;
+}
+
+/* The real <input type=range> sits on top, transparent, for full a11y +
+   keyboard + pointer support; the visual track/fill/thumb are drawn beneath. */
+.input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+  z-index: 3;
+}
+
+.rail {
+  position: absolute;
+  top: 20px;
+  left: 0;
+  right: 0;
+  height: 6px;
+  background: var(--color-slider-track);
+  border-radius: 4px;
+}
+
+.fill {
+  position: absolute;
+  top: 20px;
+  left: 0;
+  height: 6px;
+  background: var(--color-slider-fill);
+  border-radius: 4px;
+}
+
+.ticks {
+  position: absolute;
+  top: 14px;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-between;
+  pointer-events: none;
+}
+
+.tick {
+  width: 2px;
+  height: 18px;
+  background: var(--color-tick);
+}
+
+.thumb {
+  position: absolute;
+  top: 8px;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  border: var(--border-primary);
+  transform: translateX(-50%);
+  box-shadow: 2px 2px 0 rgba(43, 43, 43, 0.2);
+  pointer-events: none;
+}
+
+.input:focus-visible + .rail {
+  outline: 2px solid var(--color-accent-dark);
+  outline-offset: 6px;
+  border-radius: 6px;
+}
+
+.liveLabel {
+  font-size: 0.95rem;
+  color: var(--color-accent-dark);
+  margin-top: 6px;
+  text-align: center;
+  min-height: 1.4em;
+}

--- a/frontend/src/components/Slider.tsx
+++ b/frontend/src/components/Slider.tsx
@@ -1,0 +1,49 @@
+import { labelForPercent } from '../lib/slider'
+import styles from './Slider.module.css'
+
+/**
+ * Continuous slider on 0..100. The visible track/fill/thumb are drawn under a
+ * transparent native range input so keyboard, pointer, and screen-reader support
+ * come for free. The parent owns the value (continuous) and maps it to 1..5 on
+ * commit; keyboard 1..5 is handled at the page level to jump to stops.
+ */
+export function Slider({
+  percent,
+  onChange,
+}: {
+  percent: number
+  onChange: (percent: number) => void
+}) {
+  const label = labelForPercent(percent)
+  return (
+    <div className={styles.wrap}>
+      <div className={styles.ends}>
+        <span>Very inaccurate</span>
+        <span>Neutral</span>
+        <span>Very accurate</span>
+      </div>
+      <div className={styles.track}>
+        <input
+          className={styles.input}
+          type="range"
+          min={0}
+          max={100}
+          step={1}
+          value={percent}
+          onChange={(e) => onChange(Number(e.target.value))}
+          aria-label="How accurately does this describe you?"
+          aria-valuetext={label}
+        />
+        <div className={styles.rail} />
+        <div className={styles.fill} style={{ width: `${percent}%` }} />
+        <div className={styles.ticks}>
+          {[0, 1, 2, 3, 4].map((i) => (
+            <div key={i} className={styles.tick} />
+          ))}
+        </div>
+        <div className={styles.thumb} style={{ left: `${percent}%` }} />
+      </div>
+      <div className={styles.liveLabel}>{label}</div>
+    </div>
+  )
+}

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,0 +1,2 @@
+/** Dev-only testing controls are exposed when VITE_TEST_MODE === "true". */
+export const TEST_MODE = import.meta.env.VITE_TEST_MODE === 'true'

--- a/frontend/src/lib/slider.ts
+++ b/frontend/src/lib/slider.ts
@@ -1,0 +1,33 @@
+/**
+ * Slider value model: the thumb moves continuously on 0..100, but an Answer is
+ * a discrete 1..5. Each stop sits at the centre of an equal band, so 0..100 maps
+ * to the nearest of 5 stops, and each stop maps back to a canonical percent for
+ * keyboard jumps and the initial (Neutral) position.
+ */
+
+export const STOP_LABELS = [
+  'Very inaccurate',
+  'Moderately inaccurate',
+  'Neutral',
+  'Moderately accurate',
+  'Very accurate',
+] as const
+
+/** Continuous 0..100 -> nearest discrete Answer 1..5. */
+export function percentToValue(percent: number): number {
+  const clamped = Math.min(100, Math.max(0, percent))
+  return Math.round(clamped / 25) + 1
+}
+
+/** Discrete Answer 1..5 -> its canonical 0..100 thumb position. */
+export function valueToPercent(value: number): number {
+  return (value - 1) * 25
+}
+
+/** Live label under the slider for a continuous position. */
+export function labelForPercent(percent: number): string {
+  return STOP_LABELS[percentToValue(percent) - 1]
+}
+
+/** Centered Neutral (value 3) — the starting position for each item. */
+export const NEUTRAL_PERCENT = valueToPercent(3)

--- a/frontend/src/lib/useCountdown.ts
+++ b/frontend/src/lib/useCountdown.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Recreates the reference TimeBar semantics in React: a 30s soft timer driven by
+ * requestAnimationFrame against performance.now(), reporting elapsed each frame
+ * and firing `onExpire` once when it runs out. Resets cleanly whenever `resetKey`
+ * changes (a new item), mirroring the Vue TimeBar's "reset elapsed to 0 on
+ * advance" behaviour. `paused` suspends the loop (keeping accumulated time) so
+ * e.g. a confirm dialog does not eat the clock.
+ *
+ * Accumulated elapsed lives in a ref (not state) so it is immune to render
+ * batching: on advance the ref is zeroed synchronously in render, before the
+ * rAF effect re-runs, which is what prevents a stale ~30s value from making the
+ * next item expire instantly.
+ *
+ * Returns `progress` (0..1) for the thin bar and `remainingMs` for the label.
+ */
+export function useCountdown(
+  durationMs: number,
+  resetKey: unknown,
+  onExpire: () => void,
+  paused = false,
+): { progress: number; remainingMs: number } {
+  const [, forceTick] = useState(0)
+  const elapsedRef = useRef(0)
+  const firedRef = useRef(false)
+  const prevKeyRef = useRef(resetKey)
+  const onExpireRef = useRef(onExpire)
+  onExpireRef.current = onExpire
+
+  // Reset synchronously during render when the item changes, so the rAF effect
+  // below always starts from a clean elapsed=0 for the new item.
+  if (prevKeyRef.current !== resetKey) {
+    prevKeyRef.current = resetKey
+    elapsedRef.current = 0
+    firedRef.current = false
+  }
+
+  useEffect(() => {
+    if (paused || firedRef.current) return
+    let handle = 0
+    // Anchor so already-accumulated time (from before a pause) keeps counting.
+    const anchor = performance.now() - elapsedRef.current
+
+    const tick = () => {
+      elapsedRef.current = performance.now() - anchor
+      forceTick((n) => n + 1)
+      if (elapsedRef.current >= durationMs) {
+        if (!firedRef.current) {
+          firedRef.current = true
+          onExpireRef.current()
+        }
+        return
+      }
+      handle = requestAnimationFrame(tick)
+    }
+    handle = requestAnimationFrame(tick)
+
+    return () => cancelAnimationFrame(handle)
+    // resetKey drives a full restart; paused suspends/resumes the loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [durationMs, resetKey, paused])
+
+  const elapsed = Math.min(elapsedRef.current, durationMs)
+  const progress = Math.min(elapsed / durationMs, 1)
+  const remainingMs = Math.max(durationMs - elapsed, 0)
+  return { progress, remainingMs }
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -3,15 +3,20 @@ import { createBrowserRouter } from 'react-router'
 import { AppShell } from './components/AppShell'
 import { CoachPage } from './routes/CoachPage'
 import { ReportPage } from './routes/ReportPage'
+import { ScoringPage } from './routes/ScoringPage'
 import { StartPage } from './routes/StartPage'
 import { TestPage } from './routes/TestPage'
 
 export const router = createBrowserRouter([
+  // Start and Test render their own full-bleed chrome (per the design handoff:
+  // a marketing top-nav on Start, a slim test header on Test), so they sit
+  // outside the shared AppShell.
+  { path: '/', element: <StartPage /> },
+  { path: '/test', element: <TestPage /> },
+  { path: '/test/scoring', element: <ScoringPage /> },
   {
     element: <AppShell />,
     children: [
-      { path: '/', element: <StartPage /> },
-      { path: '/test', element: <TestPage /> },
       { path: '/report/:runId', element: <ReportPage /> },
       { path: '/coach', element: <CoachPage /> },
     ],

--- a/frontend/src/routes/ReportPage.module.css
+++ b/frontend/src/routes/ReportPage.module.css
@@ -1,0 +1,88 @@
+.wrap {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--color-accent);
+  letter-spacing: 1px;
+  margin-bottom: 8px;
+}
+
+.h1 {
+  margin: 0 0 6px;
+}
+
+.note {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  margin: 0 0 24px;
+}
+
+.card {
+  background: var(--color-card);
+  border: var(--border-primary);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-sticker);
+  padding: 24px 26px;
+}
+
+.cardTitle {
+  font-family: var(--font-serif);
+  font-size: 1.2rem;
+  margin: 0 0 18px;
+}
+
+.bar {
+  margin-bottom: 16px;
+}
+
+.barHead {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.95rem;
+  margin-bottom: 6px;
+}
+
+.barName {
+  font-weight: 500;
+}
+
+.barScore {
+  font-family: var(--font-mono);
+  color: var(--color-secondary);
+}
+
+.barTrack {
+  height: 10px;
+  background: var(--border-divider);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.barFill {
+  height: 100%;
+  background: var(--color-accent);
+  border-radius: 6px;
+}
+
+.status {
+  background: var(--color-card);
+  border: var(--border-neutral);
+  border-radius: var(--radius-card);
+  padding: 28px 26px;
+  text-align: center;
+}
+
+.statusText {
+  color: var(--color-secondary);
+  margin: 0 0 16px;
+}
+
+.link {
+  color: var(--color-accent-dark);
+  font-weight: 600;
+  text-decoration: none;
+}

--- a/frontend/src/routes/ReportPage.tsx
+++ b/frontend/src/routes/ReportPage.tsx
@@ -1,12 +1,85 @@
-import { useParams } from 'react-router'
+import { useQuery } from '@tanstack/react-query'
+import { Link, useParams } from 'react-router'
 
-import { Placeholder } from '../components/Placeholder'
+import { api } from '../api/client'
+import styles from './ReportPage.module.css'
 
+/**
+ * Placeholder report (the real 2d narrative report is PR4). Shows the five
+ * domain percentiles as plain bars for a completed run, and handles the
+ * in_progress / abandoned / error cases gracefully.
+ */
 export function ReportPage() {
   const { runId } = useParams()
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['test-run', runId],
+    queryFn: () => api.getTestRun(runId as string),
+    enabled: Boolean(runId),
+  })
+
+  if (isLoading) {
+    return (
+      <div className={styles.wrap}>
+        <p className={styles.note}>Loading your report…</p>
+      </div>
+    )
+  }
+
+  if (isError || !data) {
+    return (
+      <div className={styles.wrap}>
+        <div className={styles.status}>
+          <p className={styles.statusText}>We couldn&rsquo;t load that run.</p>
+          <Link className={styles.link} to="/">
+            Take the test →
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  if (data.status !== 'completed' || !data.scores) {
+    const message =
+      data.status === 'abandoned'
+        ? 'This test run was abandoned, so there is no report.'
+        : 'This test run is still in progress — finish it to see your report.'
+    return (
+      <div className={styles.wrap}>
+        <div className={styles.status}>
+          <p className={styles.statusText}>{message}</p>
+          <Link className={styles.link} to="/">
+            Start a new test →
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
   return (
-    <Placeholder title="Report">
-      <p>The report for test run {runId} renders here in a later PR.</p>
-    </Placeholder>
+    <div className={styles.wrap}>
+      <div className={styles.eyebrow}>YOUR PROFILE</div>
+      <h1 className={styles.h1}>Your five dimensions</h1>
+      <p className={styles.note}>
+        A plain-language report with strengths and watch-outs arrives soon. For
+        now, here are your percentile scores.
+      </p>
+      <div className={styles.card}>
+        <h2 className={styles.cardTitle}>Domain percentiles</h2>
+        {data.scores.domains.map((d) => (
+          <div key={d.domain} className={styles.bar}>
+            <div className={styles.barHead}>
+              <span className={styles.barName}>{d.name}</span>
+              <span className={styles.barScore}>{d.percentile}</span>
+            </div>
+            <div className={styles.barTrack}>
+              <div
+                className={styles.barFill}
+                style={{ width: `${d.percentile}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
   )
 }

--- a/frontend/src/routes/ScoringPage.module.css
+++ b/frontend/src/routes/ScoringPage.module.css
@@ -1,0 +1,124 @@
+.page {
+  min-height: 100%;
+  background: var(--color-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.card {
+  background: var(--color-card);
+  border: var(--border-primary);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-sticker);
+  padding: 60px 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 26px;
+  max-width: 460px;
+  width: 100%;
+  text-align: center;
+}
+
+.spinner {
+  width: 82px;
+  height: 82px;
+  border-radius: 50%;
+  border: 6px solid var(--border-divider);
+  border-top-color: var(--color-accent);
+  animation: spin 1s linear infinite;
+}
+
+.title {
+  font-family: var(--font-serif);
+  font-size: 1.6rem;
+  margin: 0;
+}
+
+.subtitle {
+  font-size: 0.95rem;
+  color: var(--color-muted);
+  margin: 8px 0 0;
+}
+
+.chips {
+  display: flex;
+  gap: 11px;
+}
+
+.chip {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 2px solid var(--color-ink);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 1rem;
+  background: var(--color-accent);
+  color: #fff;
+  animation: blink 1.4s infinite;
+}
+
+.bar {
+  width: 100%;
+  height: 5px;
+  background: var(--border-divider);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.barIndeterminate {
+  height: 100%;
+  width: 40%;
+  background: var(--color-accent);
+  border-radius: 3px;
+  animation: indeterminate 1.4s ease-in-out infinite;
+}
+
+@keyframes indeterminate {
+  0% {
+    margin-left: -40%;
+  }
+  100% {
+    margin-left: 100%;
+  }
+}
+
+/* Error / retry state */
+.errorTitle {
+  font-family: var(--font-serif);
+  font-size: 1.5rem;
+  margin: 0;
+}
+
+.errorText {
+  font-size: 0.95rem;
+  color: var(--color-secondary);
+  margin: 0;
+}
+
+.retry {
+  padding: 12px 32px;
+  border-radius: 24px;
+  background: var(--color-accent);
+  border: var(--border-primary);
+  color: #fff;
+  font: inherit;
+  font-weight: 700;
+  box-shadow: var(--shadow-button);
+  cursor: pointer;
+}
+
+.exitLink {
+  background: none;
+  border: none;
+  color: var(--color-muted);
+  font: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+  text-decoration: underline;
+}

--- a/frontend/src/routes/ScoringPage.tsx
+++ b/frontend/src/routes/ScoringPage.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router'
+
+import { api } from '../api/client'
+import { useRunStore } from '../store/runStore'
+import styles from './ScoringPage.module.css'
+
+const CHIPS = ['O', 'C', 'E', 'A', 'N']
+
+type Phase = 'scoring' | 'error'
+
+/**
+ * Screen 2c: covers the POST /complete call. On success routes to the report;
+ * on failure shows a simple, on-tone retry state (error states are a design gap
+ * per the handoff).
+ */
+export function ScoringPage() {
+  const navigate = useNavigate()
+  const runId = useRunStore((s) => s.runId)
+  const reset = useRunStore((s) => s.reset)
+  const [phase, setPhase] = useState<Phase>('scoring')
+  const startedRef = useRef(false)
+
+  useEffect(() => {
+    if (!runId) {
+      navigate('/', { replace: true })
+      return
+    }
+    // StrictMode double-invokes effects in dev; complete exactly once.
+    if (startedRef.current) return
+    startedRef.current = true
+    void run()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  async function run() {
+    if (!runId) return
+    setPhase('scoring')
+    try {
+      await api.completeTestRun(runId)
+      const id = runId
+      reset()
+      navigate(`/report/${id}`, { replace: true })
+    } catch {
+      setPhase('error')
+    }
+  }
+
+  function retry() {
+    startedRef.current = true
+    void run()
+  }
+
+  if (phase === 'error') {
+    return (
+      <div className={styles.page}>
+        <div className={styles.card}>
+          <h1 className={styles.errorTitle}>We couldn&rsquo;t score that run</h1>
+          <p className={styles.errorText}>
+            Something went wrong reaching the scorer. Your answers are saved — try
+            again.
+          </p>
+          <button className={styles.retry} onClick={retry}>
+            Try again
+          </button>
+          <button
+            className={styles.exitLink}
+            onClick={() => {
+              reset()
+              navigate('/', { replace: true })
+            }}
+          >
+            Back to start
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.card}>
+        <div className={styles.spinner} aria-hidden="true" />
+        <div>
+          <h1 className={styles.title}>Analyzing your responses…</h1>
+          <p className={styles.subtitle}>Mapping you across five dimensions</p>
+        </div>
+        <div className={styles.chips} aria-hidden="true">
+          {CHIPS.map((c, i) => (
+            <div
+              key={c}
+              className={styles.chip}
+              style={{ animationDelay: `${i * 0.2}s` }}
+            >
+              {c}
+            </div>
+          ))}
+        </div>
+        <div className={styles.bar}>
+          <div className={styles.barIndeterminate} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/routes/StartPage.module.css
+++ b/frontend/src/routes/StartPage.module.css
@@ -1,0 +1,285 @@
+.page {
+  min-height: 100%;
+  background: var(--color-bg);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  padding: 15px 26px;
+  border-bottom: 2px solid var(--border-divider);
+  background: var(--color-card);
+}
+
+.wordmark {
+  font-family: var(--font-serif);
+  font-weight: 600;
+  font-size: 1.3rem;
+  color: var(--color-ink);
+}
+
+.navLink {
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.navRight {
+  margin-left: auto;
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.avatar {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 2px solid var(--color-ink);
+  background: var(--color-tint);
+}
+
+.hero {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 56px 24px 72px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--color-accent);
+  letter-spacing: 1px;
+  margin-bottom: 12px;
+}
+
+.h1 {
+  font-size: 2.6rem;
+  line-height: 1.06;
+  max-width: 640px;
+  margin: 0;
+}
+
+.subcopy {
+  font-size: 1.05rem;
+  line-height: 1.5;
+  color: var(--color-secondary);
+  max-width: 520px;
+  margin: 16px 0 0;
+}
+
+.pickLabel {
+  font-size: 0.95rem;
+  color: var(--color-muted);
+  margin: 32px 0 14px;
+}
+
+.cards {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.card {
+  width: 250px;
+  border: var(--border-neutral);
+  border-radius: 18px;
+  padding: 20px 20px 22px;
+  text-align: left;
+  background: var(--color-card);
+  position: relative;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+
+.cardSelected {
+  border: var(--border-primary);
+  background: var(--color-tint);
+  box-shadow: var(--shadow-accent-card);
+}
+
+.cardDisabled {
+  cursor: not-allowed;
+  opacity: 0.72;
+}
+
+.cardHead {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.cardTitle {
+  font-family: var(--font-serif);
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.cardMeta {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
+.cardCount {
+  font-size: 0.95rem;
+  color: var(--color-secondary);
+  margin-top: 6px;
+}
+
+.cardRule {
+  height: 1.5px;
+  background: var(--border-divider);
+  margin: 12px 0;
+}
+
+.cardRuleTint {
+  background: var(--color-tint-border);
+}
+
+.cardDesc {
+  font-size: 0.85rem;
+  line-height: 1.3;
+  color: var(--color-secondary);
+}
+
+.badge {
+  position: absolute;
+  top: -11px;
+  left: 20px;
+  background: var(--color-accent);
+  color: #fff;
+  border: 2px solid var(--color-ink);
+  border-radius: 20px;
+  padding: 2px 10px;
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.badgeMuted {
+  background: var(--color-faint);
+  color: var(--color-ink);
+}
+
+/* Demographics row */
+.demographics {
+  margin-top: 30px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.demoRow {
+  display: flex;
+  gap: 14px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  text-align: left;
+}
+
+.fieldLabel {
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
+.input,
+.select {
+  font: inherit;
+  font-size: 0.95rem;
+  padding: 10px 12px;
+  border: var(--border-neutral);
+  border-radius: 12px;
+  background: var(--color-card);
+  color: var(--color-ink);
+  min-width: 120px;
+}
+
+.input:focus,
+.select:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
+.demoHint {
+  font-size: 0.78rem;
+  color: var(--color-muted);
+}
+
+.cta {
+  margin-top: 30px;
+  padding: 14px 40px;
+  border-radius: var(--radius-pill);
+  background: var(--color-accent);
+  border: var(--border-primary);
+  color: #fff;
+  font-family: var(--font-sans);
+  font-weight: 700;
+  font-size: 1.05rem;
+  box-shadow: var(--shadow-button);
+  cursor: pointer;
+}
+
+.cta:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.error {
+  color: #b3452f;
+  font-size: 0.85rem;
+  margin-top: 12px;
+}
+
+.steps {
+  display: flex;
+  gap: 34px;
+  margin-top: 40px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.step {
+  text-align: center;
+  width: 150px;
+}
+
+.stepNum {
+  font-family: var(--font-serif);
+  font-size: 1.4rem;
+  color: var(--color-accent-dark);
+}
+
+.stepText {
+  font-size: 0.8rem;
+  line-height: 1.2;
+  color: var(--color-muted);
+  margin-top: 4px;
+}
+
+.testModeHint {
+  margin-top: 20px;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--color-muted);
+  border: 1.5px dashed var(--color-accent);
+  border-radius: 8px;
+  padding: 4px 10px;
+}

--- a/frontend/src/routes/StartPage.tsx
+++ b/frontend/src/routes/StartPage.tsx
@@ -1,17 +1,171 @@
-import { Link } from 'react-router'
+import { useState } from 'react'
+import { useNavigate } from 'react-router'
 
-import { Placeholder } from '../components/Placeholder'
+import { api } from '../api/client'
+import { ensureProfileId } from '../api/profile'
+import { TEST_MODE } from '../config'
+import { useRunStore } from '../store/runStore'
+import styles from './StartPage.module.css'
+
+type Sex = 'male' | 'female' | ''
 
 export function StartPage() {
+  const navigate = useNavigate()
+  const start = useRunStore((s) => s.start)
+
+  // Test mode prefills demographics so a run can begin in one click.
+  const [age, setAge] = useState<string>(TEST_MODE ? '30' : '')
+  const [sex, setSex] = useState<Sex>(TEST_MODE ? 'male' : '')
+  const [starting, setStarting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const ageNum = Number(age)
+  const ageValid = Number.isInteger(ageNum) && ageNum >= 13 && ageNum <= 120
+  const demographicsValid = ageValid && sex !== ''
+
+  async function handleStart() {
+    if (!demographicsValid || starting) return
+    setStarting(true)
+    setError(null)
+    try {
+      const profileId = await ensureProfileId()
+      const [{ id: runId }, formData] = await Promise.all([
+        api.createTestRun({ profile_id: profileId, form: 'full', age: ageNum, sex }),
+        api.getFormItems('full'),
+      ])
+      start(runId, formData.items)
+      navigate('/test')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not start the test.')
+      setStarting(false)
+    }
+  }
+
   return (
-    <Placeholder title="Discover your Big Five">
-      <p>
-        Take an IPIP-NEO personality test with a soft per-item timer and a
-        continuous slider, then read a plain-language report of your five traits.
-      </p>
-      <p>
-        <Link to="/test">Start the test →</Link>
-      </p>
-    </Placeholder>
+    <div className={styles.page}>
+      <nav className={styles.nav}>
+        <span className={styles.wordmark}>Big Five</span>
+        <span className={styles.navLink}>How it works</span>
+        <span className={styles.navLink}>The science</span>
+        <div className={styles.navRight}>
+          <span>Sign in</span>
+          <span className={styles.avatar} aria-hidden="true" />
+        </div>
+      </nav>
+
+      <div className={styles.hero}>
+        <div className={styles.eyebrow}>SCIENCE-BACKED · BIG FIVE / IPIP-NEO</div>
+        <h1 className={styles.h1}>
+          Discover the five traits that shape how you think &amp; act
+        </h1>
+        <p className={styles.subcopy}>
+          Answer honestly and quickly — a soft 30-second timer keeps you on
+          instinct. Then get a plain-language report and, if you like, a coach
+          who knows your results.
+        </p>
+
+        <div className={styles.pickLabel}>Pick your length</div>
+        <div className={styles.cards}>
+          {/* Quick is disabled until PR6 (ADR-0004): coming soon, not selectable. */}
+          <div
+            className={`${styles.card} ${styles.cardDisabled}`}
+            aria-disabled="true"
+          >
+            <span className={`${styles.badge} ${styles.badgeMuted}`}>
+              Coming soon
+            </span>
+            <div className={styles.cardHead}>
+              <span className={styles.cardTitle}>Quick</span>
+              <span className={styles.cardMeta}>~10 min</span>
+            </div>
+            <div className={styles.cardCount}>60 statements</div>
+            <div className={styles.cardRule} />
+            <div className={styles.cardDesc}>
+              Solid five-trait scores. Great for a first read.
+            </div>
+          </div>
+
+          <div
+            className={`${styles.card} ${styles.cardSelected}`}
+            aria-pressed="true"
+          >
+            <span className={styles.badge}>Recommended</span>
+            <div className={styles.cardHead}>
+              <span className={styles.cardTitle}>Full</span>
+              <span className={styles.cardMeta}>~20 min</span>
+            </div>
+            <div className={styles.cardCount}>120 statements</div>
+            <div className={`${styles.cardRule} ${styles.cardRuleTint}`} />
+            <div className={styles.cardDesc}>
+              Adds facet-level nuance and a richer report + coach.
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.demographics}>
+          <div className={styles.demoRow}>
+            <label className={styles.field}>
+              <span className={styles.fieldLabel}>Age</span>
+              <input
+                className={styles.input}
+                type="number"
+                inputMode="numeric"
+                min={13}
+                max={120}
+                value={age}
+                onChange={(e) => setAge(e.target.value)}
+                placeholder="e.g. 30"
+                required
+              />
+            </label>
+            <label className={styles.field}>
+              <span className={styles.fieldLabel}>Sex</span>
+              <select
+                className={styles.select}
+                value={sex}
+                onChange={(e) => setSex(e.target.value as Sex)}
+                required
+              >
+                <option value="">Select…</option>
+                <option value="male">Male</option>
+                <option value="female">Female</option>
+              </select>
+            </label>
+          </div>
+          <div className={styles.demoHint}>
+            Used to compare you against people like you.
+          </div>
+        </div>
+
+        <button
+          className={styles.cta}
+          onClick={handleStart}
+          disabled={!demographicsValid || starting}
+        >
+          {starting ? 'Starting…' : 'Start the Full test →'}
+        </button>
+        {error && <div className={styles.error}>{error}</div>}
+        {TEST_MODE && (
+          <div className={styles.testModeHint}>
+            ⚡ test mode — demographics prefilled
+          </div>
+        )}
+
+        <div className={styles.steps}>
+          <div className={styles.step}>
+            <div className={styles.stepNum}>①</div>
+            <div className={styles.stepText}>Rate statements on a slider</div>
+          </div>
+          <div className={styles.step}>
+            <div className={styles.stepNum}>②</div>
+            <div className={styles.stepText}>Get your five-trait report</div>
+          </div>
+          <div className={styles.step}>
+            <div className={styles.stepNum}>③</div>
+            <div className={styles.stepText}>Spin up a personal coach</div>
+          </div>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/frontend/src/routes/TestPage.module.css
+++ b/frontend/src/routes/TestPage.module.css
@@ -1,0 +1,217 @@
+.page {
+  min-height: 100%;
+  background: var(--color-bg);
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 13px 26px;
+  border-bottom: 2px solid var(--border-divider);
+  background: var(--color-card);
+}
+
+.wordmark {
+  font-family: var(--font-serif);
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.progressArea {
+  flex: 1;
+  margin: 0 10px;
+}
+
+.progressMeta {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--color-muted);
+}
+
+.progressBar {
+  height: 5px;
+  background: var(--border-divider);
+  border-radius: 3px;
+  margin-top: 5px;
+  overflow: hidden;
+}
+
+.progressFill {
+  height: 100%;
+  background: var(--color-accent);
+  border-radius: 3px;
+  transition: width 0.2s ease;
+}
+
+/* The per-item soft timer — a separate thin bar under the progress bar. */
+.timerBar {
+  height: 3px;
+  background: transparent;
+  border-radius: 3px;
+  margin-top: 3px;
+  overflow: hidden;
+}
+
+.timerFill {
+  height: 100%;
+  background: var(--color-faint);
+  border-radius: 3px;
+}
+
+.exit {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.exit:hover {
+  color: var(--color-ink);
+}
+
+.body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 56px 24px 60px;
+}
+
+.prompt {
+  font-size: 0.95rem;
+  color: var(--color-muted);
+  margin-bottom: 10px;
+}
+
+.statement {
+  font-family: var(--font-serif);
+  font-size: 2.2rem;
+  line-height: 1.15;
+  max-width: 640px;
+  min-height: 96px;
+  margin: 0;
+}
+
+.actions {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  margin-top: 36px;
+}
+
+.next {
+  padding: 12px 40px;
+  border-radius: 24px;
+  background: var(--color-accent);
+  border: var(--border-primary);
+  color: #fff;
+  font-family: var(--font-sans);
+  font-weight: 700;
+  font-size: 1rem;
+  box-shadow: var(--shadow-button);
+  cursor: pointer;
+}
+
+.next:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.helper {
+  font-size: 0.8rem;
+  color: var(--color-faint);
+  margin-top: 14px;
+}
+
+.autofill {
+  margin-top: 24px;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--color-accent-dark);
+  background: var(--color-tint);
+  border: 1.5px dashed var(--color-accent);
+  border-radius: 10px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+.autofill:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Exit confirm dialog */
+.dialogBackdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(43, 43, 43, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+}
+
+.dialog {
+  background: var(--color-card);
+  border: var(--border-primary);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-sticker);
+  padding: 28px 30px;
+  max-width: 380px;
+  text-align: center;
+}
+
+.dialogTitle {
+  font-family: var(--font-serif);
+  font-size: 1.3rem;
+  margin: 0 0 8px;
+}
+
+.dialogText {
+  font-size: 0.95rem;
+  color: var(--color-secondary);
+  margin: 0 0 20px;
+}
+
+.dialogActions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+
+.dialogCancel {
+  padding: 10px 22px;
+  border-radius: 22px;
+  border: var(--border-neutral);
+  background: var(--color-card);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.dialogConfirm {
+  padding: 10px 22px;
+  border-radius: 22px;
+  border: var(--border-primary);
+  background: #b3452f;
+  color: #fff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.center {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-secondary);
+}

--- a/frontend/src/routes/TestPage.tsx
+++ b/frontend/src/routes/TestPage.tsx
@@ -1,9 +1,217 @@
-import { Placeholder } from '../components/Placeholder'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router'
+
+import { api } from '../api/client'
+import { Slider } from '../components/Slider'
+import { TEST_MODE } from '../config'
+import { NEUTRAL_PERCENT, percentToValue } from '../lib/slider'
+import { useCountdown } from '../lib/useCountdown'
+import { useRunStore } from '../store/runStore'
+import styles from './TestPage.module.css'
+
+const TIMER_MS = 30_000
+
+function formatRemaining(ms: number): string {
+  const total = Math.ceil(ms / 1000)
+  const m = Math.floor(total / 60)
+  const s = total % 60
+  return `${m}:${s.toString().padStart(2, '0')}`
+}
 
 export function TestPage() {
+  const navigate = useNavigate()
+  const runId = useRunStore((s) => s.runId)
+  const items = useRunStore((s) => s.items)
+  const index = useRunStore((s) => s.index)
+  const commit = useRunStore((s) => s.commit)
+  const next = useRunStore((s) => s.next)
+
+  const [percent, setPercent] = useState(NEUTRAL_PERCENT)
+  const [showExit, setShowExit] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [autofilling, setAutofilling] = useState(false)
+
+  // Guards a single commit per item across the expiry-vs-click race: each item
+  // may be committed exactly once. Reset when the item changes.
+  const committedItemRef = useRef<number | null>(null)
+
+  const item = items[index]
+  const total = items.length
+
+  // No active run (e.g. deep-link / refresh): send the user back to Start.
+  useEffect(() => {
+    if (!runId || total === 0) navigate('/', { replace: true })
+  }, [runId, total, navigate])
+
+  // Fresh slider (centered Neutral) and a clean commit guard for each new item.
+  useEffect(() => {
+    setPercent(NEUTRAL_PERCENT)
+    committedItemRef.current = null
+  }, [index])
+
+  const advance = useCallback(
+    async (value: number) => {
+      if (!runId || !item) return
+      // One commit per item — expiry and click can both fire.
+      if (committedItemRef.current === item.id) return
+      committedItemRef.current = item.id
+      setBusy(true)
+      try {
+        await api.submitAnswer({ runId, item_id: item.id, value })
+        commit(item.id, value)
+        if (index + 1 >= total) {
+          navigate('/test/scoring')
+        } else {
+          next()
+        }
+      } catch {
+        // Allow a retry on failure by clearing the guard.
+        committedItemRef.current = null
+      } finally {
+        setBusy(false)
+      }
+    },
+    [runId, item, index, total, commit, next, navigate],
+  )
+
+  const onExpire = useCallback(() => {
+    // Commit the slider as it stands (untouched = Neutral).
+    void advance(percentToValue(percent))
+  }, [advance, percent])
+
+  const { progress: timerProgress, remainingMs } = useCountdown(
+    TIMER_MS,
+    index,
+    onExpire,
+    showExit, // pause the soft timer while the exit dialog is open
+  )
+
+  // Keyboard 1..5 jumps to that stop; Enter / → commits.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (showExit) return
+      if (e.key >= '1' && e.key <= '5') {
+        setPercent((Number(e.key) - 1) * 25)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [showExit])
+
+  async function handleAutofill() {
+    if (!runId) return
+    setAutofilling(true)
+    // Answer every REMAINING item with a random 1..5 through the normal path,
+    // then complete and route to the report.
+    try {
+      for (let i = index; i < total; i++) {
+        const it = items[i]
+        const value = Math.floor(Math.random() * 5) + 1
+        await api.submitAnswer({ runId, item_id: it.id, value })
+        commit(it.id, value)
+      }
+      navigate('/test/scoring')
+    } catch {
+      setAutofilling(false)
+    }
+  }
+
+  function confirmExit() {
+    setShowExit(false)
+    if (runId) void api.abandonTestRun(runId).catch(() => {})
+    navigate('/', { replace: true })
+  }
+
+  if (!item) {
+    return (
+      <div className={styles.page}>
+        <div className={styles.center}>Loading…</div>
+      </div>
+    )
+  }
+
+  const progressPct = ((index + (busy ? 1 : 0)) / total) * 100
+
   return (
-    <Placeholder title="Test">
-      <p>The timed slider test flow lands in a later PR.</p>
-    </Placeholder>
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <span className={styles.wordmark}>Big Five</span>
+        <div className={styles.progressArea}>
+          <div className={styles.progressMeta}>
+            <span>
+              Question {index + 1} of {total}
+            </span>
+            <span>⏱ {formatRemaining(remainingMs)} left</span>
+          </div>
+          <div className={styles.progressBar}>
+            <div
+              className={styles.progressFill}
+              style={{ width: `${progressPct}%` }}
+            />
+          </div>
+          <div className={styles.timerBar}>
+            <div
+              className={styles.timerFill}
+              style={{ width: `${(1 - timerProgress) * 100}%` }}
+            />
+          </div>
+        </div>
+        <button className={styles.exit} onClick={() => setShowExit(true)}>
+          Exit test
+        </button>
+      </header>
+
+      <div className={styles.body}>
+        <div className={styles.prompt}>How accurately does this describe you?</div>
+        <p className={styles.statement}>&ldquo;{item.text}&rdquo;</p>
+
+        <Slider percent={percent} onChange={setPercent} />
+
+        <div className={styles.actions}>
+          <button
+            className={styles.next}
+            onClick={() => advance(percentToValue(percent))}
+            disabled={busy}
+          >
+            Next →
+          </button>
+        </div>
+        <div className={styles.helper}>
+          Tip: hit 1–5 on your keyboard · auto-advances when the timer runs out
+        </div>
+
+        {TEST_MODE && (
+          <button
+            className={styles.autofill}
+            onClick={handleAutofill}
+            disabled={autofilling}
+          >
+            {autofilling ? 'Filling…' : '⚡ Autofill & finish'}
+          </button>
+        )}
+      </div>
+
+      {showExit && (
+        <div className={styles.dialogBackdrop} role="dialog" aria-modal="true">
+          <div className={styles.dialog}>
+            <h2 className={styles.dialogTitle}>Exit the test?</h2>
+            <p className={styles.dialogText}>
+              Your progress will be discarded — there&rsquo;s no resuming a run.
+            </p>
+            <div className={styles.dialogActions}>
+              <button
+                className={styles.dialogCancel}
+                onClick={() => setShowExit(false)}
+              >
+                Keep going
+              </button>
+              <button className={styles.dialogConfirm} onClick={confirmExit}>
+                Exit test
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
   )
 }

--- a/frontend/src/routes/TestPage.tsx
+++ b/frontend/src/routes/TestPage.tsx
@@ -32,8 +32,10 @@ export function TestPage() {
   const [autofilling, setAutofilling] = useState(false)
 
   // Guards a single commit per item across the expiry-vs-click race: each item
-  // may be committed exactly once. Reset when the item changes.
-  const committedItemRef = useRef<number | null>(null)
+  // may be committed exactly once (ADR-0001). A Set — never cleared on advance —
+  // so a stale expiry from the previous item can't re-commit it after the
+  // per-item reset (that ordering produced duplicate POSTs and server 409s).
+  const committedItemsRef = useRef<Set<number>>(new Set())
 
   const item = items[index]
   const total = items.length
@@ -43,18 +45,17 @@ export function TestPage() {
     if (!runId || total === 0) navigate('/', { replace: true })
   }, [runId, total, navigate])
 
-  // Fresh slider (centered Neutral) and a clean commit guard for each new item.
+  // Fresh slider (centered Neutral) for each new item.
   useEffect(() => {
     setPercent(NEUTRAL_PERCENT)
-    committedItemRef.current = null
   }, [index])
 
   const advance = useCallback(
     async (value: number) => {
       if (!runId || !item) return
       // One commit per item — expiry and click can both fire.
-      if (committedItemRef.current === item.id) return
-      committedItemRef.current = item.id
+      if (committedItemsRef.current.has(item.id)) return
+      committedItemsRef.current.add(item.id)
       setBusy(true)
       try {
         await api.submitAnswer({ runId, item_id: item.id, value })
@@ -66,7 +67,7 @@ export function TestPage() {
         }
       } catch {
         // Allow a retry on failure by clearing the guard.
-        committedItemRef.current = null
+        committedItemsRef.current.delete(item.id)
       } finally {
         setBusy(false)
       }

--- a/frontend/src/store/runStore.ts
+++ b/frontend/src/store/runStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand'
+
+import type { Item } from '../api/types'
+
+/**
+ * Client state for the active Test Run: which run, its items, where we are, and
+ * the values committed so far. Server calls (answers/complete) go through
+ * TanStack Query; this store just tracks the in-flight run so the Test screen
+ * can render without refetching. Cleared when a run ends.
+ */
+interface RunState {
+  runId: string | null
+  items: Item[]
+  index: number
+  /** Committed 1..5 values keyed by item id (mirrors what the server has). */
+  values: Record<number, number>
+
+  start: (runId: string, items: Item[]) => void
+  commit: (itemId: number, value: number) => void
+  next: () => void
+  reset: () => void
+}
+
+export const useRunStore = create<RunState>((set) => ({
+  runId: null,
+  items: [],
+  index: 0,
+  values: {},
+
+  start: (runId, items) => set({ runId, items, index: 0, values: {} }),
+  commit: (itemId, value) =>
+    set((s) => ({ values: { ...s.values, [itemId]: value } })),
+  next: () => set((s) => ({ index: s.index + 1 })),
+  reset: () => set({ runId: null, items: [], index: 0, values: {} }),
+}))

--- a/frontend/src/theme/global.css
+++ b/frontend/src/theme/global.css
@@ -40,3 +40,26 @@ h3 {
 a {
   color: var(--color-accent-dark);
 }
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/frontend/src/theme/tokens.css
+++ b/frontend/src/theme/tokens.css
@@ -12,13 +12,30 @@
   /* Accent */
   --color-accent: #5aa17a;
   --color-accent-dark: #3f7d5c;
+  --color-tint-border: #d7e5db; /* divider inside tinted cards */
 
   /* Text */
   --color-ink: #2b2b2b; /* primary text */
   --color-secondary: #6b6660; /* secondary / muted text */
+  --color-muted: #8a847b; /* muted / meta text */
+  --color-faint: #b8b2a8; /* faint hints, helper text */
+
+  /* Borders */
+  --border-primary: 2.5px solid #2b2b2b;
+  --border-neutral: 2px solid #cfcabf;
+  --border-divider: #ece8e0;
+
+  /* Slider */
+  --color-slider-track: #e2ded5;
+  --color-slider-fill: #bfe0cc;
+  --color-tick: #d3cec4;
 
   /* Status */
   --color-warn: #b58a3c;
+
+  /* Button shadow (sticker press) */
+  --shadow-button: 2px 2px 0 rgba(43, 43, 43, 0.25);
+  --shadow-accent-card: 3px 3px 0 rgba(90, 161, 122, 0.35);
 
   /* Radii */
   --radius-card: 16px;
@@ -33,6 +50,7 @@
   /* Typography */
   --font-serif: 'Source Serif 4', Georgia, 'Times New Roman', serif;
   --font-sans: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --font-mono: ui-monospace, 'SF Mono', 'SFMono-Regular', 'Menlo', monospace;
 
   /* Layout */
   --nav-height: 64px;

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_PROXY_TARGET?: string
+  /** "true" exposes dev-only testing controls (autofill, demographics prefill). */
+  readonly VITE_TEST_MODE?: string
+  readonly VITE_CLERK_PUBLISHABLE_KEY?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary
- Backend: Profile/TestRun/Answer models + migration; test-run lifecycle API (create/answer/complete/abandon/get) with one-shot answer enforcement (409 on duplicate, ADR-0001), full-completion validation, scores persisted to JSONB via the PR2 engine
- Frontend: Start screen (2a: path cards with Quick "coming soon", demographics gate), timed question screen (2b: continuous slider with 1–5 keyboard stops, 30s rAF soft timer with reference TimeBar semantics, expiry commits current slider / untouched = Neutral, no Back, Exit→confirm→abandon with paused timer), scoring transition (2c: spinner + OCEAN chips + retry state), placeholder report bars
- Test mode (VITE_TEST_MODE): demographics prefill + "⚡ Autofill & finish" through the real answer API

## Verification
- 47 backend tests green (dedicated test DB; happy path asserts parity with the pure engine); frontend build clean
- Sonnet+Playwright verification session: timer expiry advances exactly one item (no cascade), dialog pauses clock, abandon persists, report shows valid percentiles, API integrity confirmed
- Race found in verification fixed (commit guard is now a Set; stale expiry can't double-POST) — re-verified: zero console errors across the full flow
- Verifier's "CTA not disabled on empty age" flagged as blocker was a false positive (direct DOM mutation bypasses React state); reproduced correctly with real input — CTA disables as specced

🤖 Generated with [Claude Code](https://claude.com/claude-code)